### PR TITLE
style: Integrate poppins fonts

### DIFF
--- a/campus-connect/components/layout/Header.tsx
+++ b/campus-connect/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { CirclePlus, GraduationCap, LogIn } from 'lucide-react';
+import { CirclePlus, LogIn } from 'lucide-react';
 import Image from 'next/image';
 import { Button } from '../ui/button';
 import { useRouter } from 'next/navigation';

--- a/campus-connect/pages/_app.tsx
+++ b/campus-connect/pages/_app.tsx
@@ -1,9 +1,20 @@
 import Layout from "@/components/layout/Layout";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { Poppins } from "next/font/google";
+
+const poppins = Poppins({
+  weight: ["300", "400", "500", "600", "700"],
+  subsets: ["latin"],
+  variable: "--font-poppins",
+});
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Layout>
-    <Component {...pageProps} />
-  </Layout>;
+  return (
+    <main className={poppins.className}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </main>
+  );
 }

--- a/campus-connect/styles/globals.css
+++ b/campus-connect/styles/globals.css
@@ -45,7 +45,7 @@
   --color-brand-green: var(--brand-green);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-poppins), var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -95,6 +95,9 @@
 body {
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-poppins), -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 


### PR DESCRIPTION
This
This pull request updates the global typography of the application to use the Poppins font and improves font loading and rendering across the app. The changes ensure that Poppins is now the primary sans-serif font, both at the CSS variable and root level, and that it is loaded efficiently using Next.js font optimization.

**Typography and Font Loading Updates:**

* Added Poppins as a Google font using Next.js font optimization in `_app.tsx`, and wrapped the app in a `<main>` with the appropriate class for font loading.
* Updated CSS variables and the `body` selector in `globals.css` to prioritize Poppins as the main sans-serif font, and enabled font smoothing for better rendering. [[1]](diffhunk://#diff-1a90c3f5c9c93700c1d8517bcb0d588fe0bd5108d1cd97d4f1d80a18bb85a9d1L48-R48) [[2]](diffhunk://#diff-1a90c3f5c9c93700c1d8517bcb0d588fe0bd5108d1cd97d4f1d80a18bb85a9d1R98-R100)

**Minor Cleanup:**

* Removed unused `GraduationCap` icon import from `Header.tsx`.